### PR TITLE
英語版ページ追加（ブラウザ言語で自動切替）

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <script>
@@ -18,11 +18,11 @@
         })();
     </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="AI Robot Japan - 研究・開発から社会実装までを一気通貫で推進する、日本のAIロボット実務者コミュニティ">
+    <meta name="description" content="AI Robot Japan - a community of AI-robotics practitioners in Japan, driving everything from R&D to real-world deployment.">
     <meta property="og:title" content="AI Robot Japan - AI Robot Community">
-    <meta property="og:description" content="研究・開発から社会実装までを一気通貫で推進する、日本のAIロボット実務者コミュニティ。勉強会・ハッカソン・カンファレンス・Podcastを通年で展開しています。">
+    <meta property="og:description" content="A community of AI-robotics practitioners in Japan, driving everything from R&D to real-world deployment. Study sessions, hackathons, conferences, and a podcast, year-round.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://ai-robot-japan.org/">
+    <meta property="og:url" content="https://ai-robot-japan.org/en/index.html">
     <meta property="og:image" content="https://ai-robot-japan.org/assets/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="theme-color" content="#d5191f">
@@ -30,290 +30,290 @@
     <link rel="alternate" hreflang="en" href="https://ai-robot-japan.org/en/index.html">
     <link rel="alternate" hreflang="x-default" href="https://ai-robot-japan.org/index.html">
     <title>AI Robot Japan - AI Robot Community</title>
-    <link rel="icon" type="image/png" href="./assets/favicon.png">
-    <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
+    <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=9">
+    <link rel="stylesheet" href="/styles.css?v=9">
 </head>
 <body>
-    <!-- ナビゲーション -->
+    <!-- Navigation -->
     <nav class="navbar">
         <div class="container">
             <div class="nav-brand">
-                <a href="/index.html"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
+                <a href="/en/index.html"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
             <ul class="nav-menu">
-                <li><a href="#latest">新着</a></li>
-                <li><a href="#about">概要</a></li>
-                <li><a href="#activities">活動</a></li>
-                <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
+                <li><a href="#latest">Latest</a></li>
+                <li><a href="#about">About</a></li>
+                <li><a href="#activities">Activities</a></li>
+                <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">Events</a></li>
                 <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
-                <li><a href="/recruit.html">募集</a></li>
-                <li><a href="#contact" class="nav-cta">参加する</a></li>
-                <li><a href="/en/index.html" class="nav-lang" onclick="localStorage.setItem('arj-lang','en')">EN</a></li>
+                <li><a href="/en/recruit.html">Recruit</a></li>
+                <li><a href="#contact" class="nav-cta">Join</a></li>
+                <li><a href="/index.html" class="nav-lang" onclick="localStorage.setItem('arj-lang','ja')">日本語</a></li>
             </ul>
         </div>
     </nav>
 
-    <!-- ヒーローセクション -->
+    <!-- Hero -->
     <header class="hero">
         <div class="container">
             <div class="hero-inner">
                 <div class="hero-content">
                     <p class="hero-eyebrow">AI Robot Japan</p>
-                    <h1 class="hero-title">AIロボットを、<br class="title-br">つくって動かす。</h1>
-                    <p class="hero-subtitle">研究・開発から社会実装までを一気通貫で推進する、日本のAIロボット実務者コミュニティ。<br>勉強会・ハッカソン・カンファレンス・Podcastを通年で展開し、領域を越えた共創を促進します。</p>
+                    <h1 class="hero-title">Build and run<br class="title-br">AI robots.</h1>
+                    <p class="hero-subtitle">A community of AI-robotics practitioners in Japan, driving everything from R&amp;D to real-world deployment.<br>We run study sessions, hackathons, conferences, and a podcast year-round, fostering collaboration across disciplines.</p>
                     <div class="hero-actions">
-                        <a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Discordに参加する</a>
-                        <a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">イベントを見る</a>
+                        <a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Join our Discord</a>
+                        <a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">See events</a>
                     </div>
                 </div>
                 <div class="hero-visual">
-                    <img src="./assets/logo-mark.png" alt="AI Robot Japan ロゴ">
+                    <img src="/assets/logo-mark.png" alt="AI Robot Japan logo">
                 </div>
             </div>
             <div class="hero-stats">
                 <div class="stat">
                     <span class="stat-number">650<small>+</small></span>
-                    <span class="stat-label">connpassメンバー</span>
+                    <span class="stat-label">connpass members</span>
                 </div>
                 <div class="stat">
                     <span class="stat-number" id="stat-episodes">11</span>
-                    <span class="stat-label">Podcastエピソード</span>
+                    <span class="stat-label">Podcast episodes</span>
                 </div>
                 <div class="stat">
-                    <span class="stat-number">4<small>都市+</small></span>
-                    <span class="stat-label">開催エリア（全国展開を検討中）</span>
+                    <span class="stat-number">4<small>cities+</small></span>
+                    <span class="stat-label">Areas (nationwide planned)</span>
                 </div>
             </div>
         </div>
     </header>
 
-    <!-- 新着コンテンツセクション -->
+    <!-- Latest -->
     <section id="latest" class="section latest">
         <div class="container">
             <p class="section-eyebrow">LATEST</p>
-            <h2 class="section-title">新着コンテンツ</h2>
+            <h2 class="section-title">Latest</h2>
             <div class="contents-grid">
                 <article class="content-card">
                     <div class="content-card-header">
-                        <h3>イベント</h3>
-                        <a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer" class="content-more">すべて見る →</a>
+                        <h3>Events</h3>
+                        <a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer" class="content-more">View all →</a>
                     </div>
                     <div class="content-preview-grid" id="events-preview" aria-live="polite">
-                        <p class="content-loading">イベント情報を読み込み中です…</p>
+                        <p class="content-loading">Loading events…</p>
                     </div>
                 </article>
                 <article class="content-card">
                     <div class="content-card-header">
                         <h3>Podcast</h3>
-                        <a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer" class="content-more">すべて見る →</a>
+                        <a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer" class="content-more">View all →</a>
                     </div>
                     <div class="content-preview-grid" id="podcast-preview" aria-live="polite">
-                        <p class="content-loading">Podcast情報を読み込み中です…</p>
+                        <p class="content-loading">Loading podcast…</p>
                     </div>
                 </article>
             </div>
         </div>
     </section>
 
-    <!-- 概要セクション -->
+    <!-- About -->
     <section id="about" class="section about">
         <div class="container">
             <p class="section-eyebrow">ABOUT</p>
-            <h2 class="section-title">AI Robot Japanとは</h2>
+            <h2 class="section-title">About AI Robot Japan</h2>
             <div class="about-content">
                 <p class="lead">
-                    AI Robot Japanは、AIロボットを中核に、研究・開発から社会実装までを一気通貫で推進するためのコミュニティです。
+                    AI Robot Japan is a community driving AI robotics end-to-end, from research and development to real-world deployment.
                 </p>
                 <p>
-                    生成AI・機械学習の進展により、認識・推論・計画・制御が統合されつつある今、ロボットを動かすための実装知と産業知を結集し、日本の競争力強化（国力・産業基盤の再構築）に資するエコシステム形成を目指します。
+                    As generative AI and machine learning increasingly integrate perception, reasoning, planning, and control, we bring together the engineering and industry know-how needed to make robots work — aiming to build an ecosystem that strengthens Japan's competitiveness and industrial base.
                 </p>
                 <p>
-                    日本では、ハードウェア人材とAI/ソフトウェア人材の分断により、知見や人材が領域内に閉じがちです。本コミュニティは両者を横断的に接続し、データ・モデル・ハードウェアを統合した開発体制（R&D—PoC—プロダクト化）の確立を支援する「融合の場」を提供します。
+                    In Japan, hardware talent and AI/software talent are often siloed. We connect the two, providing a place to accelerate integrated development across data, models, and hardware (R&amp;D–PoC–productization).
                 </p>
                 <p>
-                    米中を中心に国際競争が激化するなか、日本のAIロボット推進を支える実務者ネットワーク・共創基盤として機能します。
+                    Amid intensifying global competition, we serve as a practitioner network and co-creation platform for advancing AI robotics in Japan.
                 </p>
             </div>
         </div>
     </section>
 
-    <!-- 雰囲気セクション -->
+    <!-- Culture -->
     <section id="atmosphere" class="section atmosphere">
         <div class="container">
             <p class="section-eyebrow">CULTURE</p>
-            <h2 class="section-title">大切にしていること</h2>
-            <p class="atmosphere-quote">「つくって動かす」体験を、コミュニティの中心に。</p>
+            <h2 class="section-title">What we value</h2>
+            <p class="atmosphere-quote">Putting the “build and run” experience at the center.</p>
             <div class="atmosphere-content">
                 <p>
-                    AI Robot Japanは、AIロボットを「つくって動かす」体験を何よりも重視します。最先端の情報を追うだけでなく、実機・デモ・プロトタイピングを通じて、学びと熱量が循環する場を運営します。
+                    AI Robot Japan values the hands-on experience of building and running AI robots above all. Beyond following the latest research, we run a place where learning and momentum circulate through real machines, demos, and prototyping.
                 </p>
                 <p>
-                    AIロボットは、ソフトウェア・ハードウェア・製造・研究・事業が交差する領域です。異業種・異分野の実務者が交わることで生まれる、偶発的な出会いと共創の機会を大切にします。
+                    AI robotics sits at the intersection of software, hardware, manufacturing, research, and business. We cherish the serendipitous encounters and co-creation that arise when practitioners from different fields mix.
                 </p>
                 <p>
-                    基本スタンスはオープンです。初心者から第一線の実務者までが、相互のリスペクトのもとで議論し、協力し、挑戦できるコミュニティを目指します。
+                    Our stance is open. We aim to be a community where everyone, from beginners to leading practitioners, can discuss, collaborate, and take on challenges with mutual respect.
                 </p>
             </div>
             <div class="culture-marquee">
                 <div class="culture-marquee-track">
-                    <img src="./assets/photos/event-stage.jpg" alt="AI ROBOT JAPAN × STATION Ai 共催 勉強会のステージ" loading="lazy">
-                    <img src="./assets/photos/event-agirobots.jpg" alt="AGIRobots のモバイルマニピュレータ実機" loading="lazy">
-                    <img src="./assets/photos/event-ugo.jpg" alt="ugo による実機デモと参加者の交流の様子" loading="lazy">
-                    <img src="./assets/photos/event-lineup.jpg" alt="会場に並んだ各社のヒューマノイド・ロボットアーム" loading="lazy">
-                    <img src="./assets/photos/event-gripper.jpg" alt="テレオペ用グリッパーのクローズアップ" loading="lazy">
-                    <img src="./assets/photos/event-talk.jpg" alt="AIロボット・データファクトリーをテーマにした登壇の様子" loading="lazy">
-                    <img src="./assets/photos/event-humanoid.jpg" alt="二足歩行ヒューマノイドの持ち込み展示" loading="lazy">
-                    <img src="./assets/photos/event-realman.jpg" alt="Realman ヒューマノイドとテレオペ機材" loading="lazy">
-                    <img src="./assets/photos/event-teleop.jpg" alt="バイマニュアルのテレオペレーション機材" loading="lazy">
-                    <img src="./assets/photos/event-lab.jpg" alt="実機の製作・調整を行うラボの様子" loading="lazy">
-                    <img src="./assets/photos/event-signage.jpg" alt="勉強会の会場サイネージ" loading="lazy">
-                    <img src="./assets/photos/event-stage.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-agirobots.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-ugo.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-lineup.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-gripper.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-talk.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-humanoid.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-realman.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-teleop.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-lab.jpg" alt="" aria-hidden="true" loading="lazy">
-                    <img src="./assets/photos/event-signage.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-stage.jpg" alt="Stage at the AI ROBOT JAPAN × STATION Ai co-hosted meetup" loading="lazy">
+                    <img src="/assets/photos/event-agirobots.jpg" alt="AGIRobots mobile manipulator" loading="lazy">
+                    <img src="/assets/photos/event-ugo.jpg" alt="ugo live demo and attendees" loading="lazy">
+                    <img src="/assets/photos/event-lineup.jpg" alt="Humanoids and robot arms lined up at the venue" loading="lazy">
+                    <img src="/assets/photos/event-gripper.jpg" alt="Close-up of a teleoperation gripper" loading="lazy">
+                    <img src="/assets/photos/event-talk.jpg" alt="A talk on AI robotics data factories" loading="lazy">
+                    <img src="/assets/photos/event-humanoid.jpg" alt="Bipedal humanoid on display" loading="lazy">
+                    <img src="/assets/photos/event-realman.jpg" alt="Realman humanoid and teleoperation rig" loading="lazy">
+                    <img src="/assets/photos/event-teleop.jpg" alt="Bimanual teleoperation rig" loading="lazy">
+                    <img src="/assets/photos/event-lab.jpg" alt="Lab bench for building and tuning machines" loading="lazy">
+                    <img src="/assets/photos/event-signage.jpg" alt="Venue signage for the meetup" loading="lazy">
+                    <img src="/assets/photos/event-stage.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-agirobots.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-ugo.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-lineup.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-gripper.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-talk.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-humanoid.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-realman.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-teleop.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-lab.jpg" alt="" aria-hidden="true" loading="lazy">
+                    <img src="/assets/photos/event-signage.jpg" alt="" aria-hidden="true" loading="lazy">
                 </div>
             </div>
-            <p class="culture-gallery-note">AIロボット持ち込み勉強会（STATION Ai ほか）の様子</p>
+            <p class="culture-gallery-note">Scenes from our bring-your-robot meetups (at STATION Ai and beyond)</p>
         </div>
     </section>
 
-    <!-- 活動セクション -->
+    <!-- Activities -->
     <section id="activities" class="section activities">
         <div class="container">
             <p class="section-eyebrow">ACTIVITIES</p>
-            <h2 class="section-title">活動</h2>
-            <p class="section-note">勉強会・ハッカソンから年次カンファレンス、Podcastによる情報発信まで、通年で活動しています。</p>
+            <h2 class="section-title">Activities</h2>
+            <p class="section-note">From study sessions and hackathons to our annual conference and podcast — we are active year-round.</p>
             <div class="activities-grid">
                 <div class="activity-card">
                     <span class="activity-icon" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4h6a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H2z"/><path d="M22 4h-6a4 4 0 0 0-4 4v12a3 3 0 0 1 3-3h7z"/></svg>
                     </span>
-                    <h3>勉強会・ハンズオン</h3>
-                    <p>実機のデモ・持ち込みや実装レビューを中心とした、実践本位の技術交流の場です。</p>
+                    <h3>Study sessions &amp; hands-on</h3>
+                    <p>Practical technical exchange centered on live demos, bring-your-own machines, and implementation reviews.</p>
                 </div>
                 <div class="activity-card">
                     <span class="activity-icon" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
                     </span>
-                    <h3>ハッカソン</h3>
-                    <p>テーマを定めた短期集中開発とデモデイを通じて、アイデアを実装まで具体化します。</p>
+                    <h3>Hackathons</h3>
+                    <p>Short, focused builds around a theme, culminating in demo days that take ideas all the way to implementation.</p>
                 </div>
                 <div class="activity-card">
                     <span class="activity-icon" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="22"/></svg>
                     </span>
-                    <h3>年次カンファレンス</h3>
-                    <p>研究・産業・政策を接続し、技術潮流の整理と共有を行う年次の場です。</p>
+                    <h3>Annual conference</h3>
+                    <p>A yearly venue connecting research, industry, and policy, and mapping where the technology is heading.</p>
                 </div>
                 <div class="activity-card">
                     <span class="activity-icon" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1.5"/></svg>
                     </span>
-                    <h3>情報発信</h3>
-                    <p>Podcast等を通じて、フィジカルAIの最新動向・論文・事例を継続的に解説します。</p>
+                    <h3>Outreach</h3>
+                    <p>Ongoing commentary on the latest physical-AI trends, papers, and case studies via our podcast and more.</p>
                 </div>
                 <div class="activity-card">
                     <span class="activity-icon" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
                     </span>
-                    <h3>交流・マッチング</h3>
-                    <p>領域横断の人材交流を促進し、共同研究・共同開発の起点をつくります。</p>
+                    <h3>Networking &amp; matching</h3>
+                    <p>Cross-domain networking that seeds joint research and co-development.</p>
                 </div>
             </div>
             <div class="scope-grid">
                 <div class="scope-block">
-                    <h3>対象領域</h3>
+                    <h3>Focus areas</h3>
                     <div class="theme-tags">
-                        <span>AI（模倣学習・強化学習・基盤モデル・マルチモーダル）</span>
-                        <span>自律性（プランニング・行動生成・SLAM）</span>
-                        <span>制御・実装（リアルタイム制御・Sim2Real・デジタルツイン）</span>
-                        <span>開発基盤（ROS 2・エッジAI・MLOps・安全/信頼性）</span>
-                        <span>産業応用（製造・物流・点検・医療介護、事業化・標準化）</span>
+                        <span>AI (imitation &amp; reinforcement learning, foundation models, multimodal)</span>
+                        <span>Autonomy (planning, action generation, SLAM)</span>
+                        <span>Control &amp; implementation (real-time control, Sim2Real, digital twins)</span>
+                        <span>Dev infrastructure (ROS 2, edge AI, MLOps, safety &amp; reliability)</span>
+                        <span>Industry applications (manufacturing, logistics, inspection, healthcare; commercialization &amp; standards)</span>
                     </div>
                 </div>
                 <div class="scope-block">
-                    <h3>開催エリア</h3>
-                    <p>東京を起点に、製造業・ロボット産業の集積を踏まえ、大阪・京都・名古屋をはじめとする全国での企画・開催を検討しています。地域を越えた共創ネットワークの構築を目指します。</p>
+                    <h3>Where we meet</h3>
+                    <p>Starting in Tokyo and, given the concentration of manufacturing and robotics industry, we are planning and holding events nationwide — including Osaka, Kyoto, and Nagoya. Our goal is a co-creation network that spans regions.</p>
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- 参加・問い合わせセクション -->
+    <!-- Join -->
     <section id="contact" class="section contact">
         <div class="container">
             <p class="section-eyebrow">JOIN US</p>
-            <h2 class="section-title">参加する</h2>
+            <h2 class="section-title">Get involved</h2>
             <div class="join-grid">
                 <div class="join-card">
                     <h3>Discord</h3>
-                    <p>日々の情報交換・技術的な議論・交流はDiscordで行っています。どなたでも参加いただけます。</p>
-                    <a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer" class="btn btn-content">Discordに参加する</a>
+                    <p>Day-to-day exchange, technical discussion, and networking happen on Discord. Everyone is welcome.</p>
+                    <a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer" class="btn btn-content">Join our Discord</a>
                 </div>
                 <div class="join-card">
-                    <h3>イベント</h3>
-                    <p>勉強会・ハッカソン等の募集はconnpassで告知しています。メンバー登録で開催通知が届きます。</p>
-                    <a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer" class="btn btn-content">connpassを開く</a>
+                    <h3>Events</h3>
+                    <p>We announce study sessions and hackathons on connpass. Join the group to get event notifications.</p>
+                    <a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer" class="btn btn-content">Open connpass</a>
                 </div>
                 <div class="join-card">
                     <h3>Podcast</h3>
-                    <p>フィジカルAIの最新動向・論文・事例を解説する番組をSpotifyで配信しています。</p>
-                    <a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer" class="btn btn-content">Spotifyで聴く</a>
+                    <p>We publish a show on the latest physical-AI trends, papers, and cases on Spotify.</p>
+                    <a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer" class="btn btn-content">Listen on Spotify</a>
                 </div>
                 <div class="join-card">
-                    <h3>お問い合わせ</h3>
-                    <p>協業・登壇・スポンサー等のご相談は、メールにてご連絡ください。</p>
+                    <h3>Contact</h3>
+                    <p>For partnerships, talks, sponsorships, and other inquiries, please email us.</p>
                     <p class="contact-email">hello@ai-robot-japan.org</p>
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- 募集バナー -->
+    <!-- Recruit banner -->
     <aside class="recruit-banner">
         <div class="container">
             <p class="recruit-banner-eyebrow">JOIN &amp; CONTRIBUTE</p>
-            <h2>一緒に、AIロボットの場をつくりませんか？</h2>
-            <p class="recruit-banner-lead">登壇・実機デモ、会場提供、協賛、運営——さまざまな形で仲間・パートナーを募集しています。</p>
-            <a href="/recruit.html" class="btn recruit-banner-btn">募集を見る</a>
+            <h2>Want to build the AI-robotics scene with us?</h2>
+            <p class="recruit-banner-lead">We are looking for members and partners in many forms — talks and demos, venues, sponsorship, and organizing.</p>
+            <a href="/en/recruit.html" class="btn recruit-banner-btn">See open roles</a>
         </div>
     </aside>
 
-    <!-- フッター -->
+    <!-- Footer -->
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
                 <div class="footer-section">
                     <h3>AI Robot Japan</h3>
-                    <p>AIロボットコミュニティ</p>
+                    <p>An AI robotics community</p>
                 </div>
                 <div class="footer-section">
-                    <h4>リンク</h4>
+                    <h4>Links</h4>
                     <ul>
-                        <li><a href="#latest">新着</a></li>
-                        <li><a href="#about">概要</a></li>
-                        <li><a href="#atmosphere">大切にしていること</a></li>
-                        <li><a href="#activities">活動</a></li>
+                        <li><a href="#latest">Latest</a></li>
+                        <li><a href="#about">About</a></li>
+                        <li><a href="#atmosphere">What we value</a></li>
+                        <li><a href="#activities">Activities</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
-                    <h4>コンテンツ</h4>
+                    <h4>Content</h4>
                     <ul>
                         <li><a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer">Discord</a></li>
-                        <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
+                        <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">Events</a></li>
                         <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
-                        <li><a href="#contact">参加する・お問い合わせ</a></li>
+                        <li><a href="/en/recruit.html">Recruit</a></li>
                     </ul>
                 </div>
             </div>
@@ -324,8 +324,8 @@
     </footer>
 
     <script>
-        const EVENTS_JSON_URL = './data/events.json';
-        const PODCAST_JSON_URL = './data/podcast.json';
+        const EVENTS_JSON_URL = '/data/events.json';
+        const PODCAST_JSON_URL = '/data/podcast.json';
 
         function buildFallbackImage(label) {
             const escapedLabel = String(label)
@@ -359,7 +359,7 @@
 
             if (options.showStatus && item.status) {
                 const status = document.createElement('span');
-                status.className = 'status-badge ' + (item.status === '開催済' ? 'status-done' : 'status-upcoming');
+                status.className = 'status-badge ' + (item.status === 'Past' ? 'status-done' : 'status-upcoming');
                 status.textContent = item.status;
                 thumbWrap.appendChild(status);
             }
@@ -393,10 +393,10 @@
         async function renderEvents(container) {
             const data = await loadJson(EVENTS_JSON_URL);
             const events = (Array.isArray(data.events) ? data.events : []).slice(0, 3).map((event) => ({
-                title: event.title || 'connpassイベント',
+                title: event.title || 'connpass event',
                 image: event.image || buildFallbackImage('connpass'),
                 url: event.url || 'https://ai-robot-japan.connpass.com/',
-                status: event.started_at && new Date(event.started_at).getTime() > Date.now() ? '開催予定' : '開催済'
+                status: event.started_at && new Date(event.started_at).getTime() > Date.now() ? 'Upcoming' : 'Past'
             }));
             if (events.length === 0) {
                 throw new Error('No events');
@@ -410,7 +410,7 @@
         async function renderPodcast(container) {
             const data = await loadJson(PODCAST_JSON_URL);
             const episodes = (Array.isArray(data.episodes) ? data.episodes : []).slice(0, 3).map((episode) => ({
-                title: episode.title || 'Podcastエピソード',
+                title: episode.title || 'Podcast episode',
                 image: episode.image || buildFallbackImage('podcast'),
                 url: episode.url || 'https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao'
             }));
@@ -435,13 +435,13 @@
             try {
                 await renderEvents(eventsContainer);
             } catch (error) {
-                renderError(eventsContainer, 'イベント情報を取得できませんでした。');
+                renderError(eventsContainer, 'Could not load events.');
             }
 
             try {
                 await renderPodcast(podcastContainer);
             } catch (error) {
-                renderError(podcastContainer, 'Podcast情報を取得できませんでした。');
+                renderError(podcastContainer, 'Could not load the podcast.');
             }
         });
     </script>

--- a/en/recruit.html
+++ b/en/recruit.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script>
+        (function () {
+            try {
+                var p = location.pathname, onEn = /^\/en(\/|$)/.test(p);
+                var s = localStorage.getItem('arj-lang');
+                var wantEn = s ? s === 'en' : (navigator.language || '').toLowerCase().indexOf('ja') !== 0;
+                if (wantEn && !onEn) {
+                    location.replace((p === '/' || p === '' ? '/en/index.html' : '/en' + p) + location.search + location.hash);
+                } else if (!wantEn && onEn) {
+                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/index.html';
+                    location.replace(t + location.search + location.hash);
+                }
+            } catch (e) {}
+        })();
+    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Get involved with AI Robot Japan — talks and live demos, hosting a venue, co-hosting & sponsorship, and joining the organizing team.">
+    <meta property="og:title" content="Recruit | AI Robot Japan">
+    <meta property="og:description" content="We are looking for members and partners to build AI Robot Japan with us: talks and live demos, venues, co-hosting & sponsorship, and organizers.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://ai-robot-japan.org/en/recruit.html">
+    <meta property="og:image" content="https://ai-robot-japan.org/assets/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="theme-color" content="#d5191f">
+    <link rel="alternate" hreflang="ja" href="https://ai-robot-japan.org/recruit.html">
+    <link rel="alternate" hreflang="en" href="https://ai-robot-japan.org/en/recruit.html">
+    <link rel="alternate" hreflang="x-default" href="https://ai-robot-japan.org/recruit.html">
+    <title>Recruit | AI Robot Japan</title>
+    <link rel="icon" type="image/png" href="/assets/favicon.png">
+    <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css?v=9">
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar">
+        <div class="container">
+            <div class="nav-brand">
+                <a href="/en/index.html"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
+            </div>
+            <ul class="nav-menu">
+                <li><a href="/en/index.html#latest">Latest</a></li>
+                <li><a href="/en/index.html#about">About</a></li>
+                <li><a href="/en/index.html#activities">Activities</a></li>
+                <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">Events</a></li>
+                <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                <li><a href="/en/recruit.html" class="nav-cta">Recruit</a></li>
+                <li><a href="/recruit.html" class="nav-lang" onclick="localStorage.setItem('arj-lang','ja')">日本語</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <!-- Page header -->
+    <header class="page-hero">
+        <div class="container">
+            <p class="hero-eyebrow">JOIN &amp; CONTRIBUTE</p>
+            <h1 class="page-hero-title">We are looking for people <br class="sp-only">to build this with us</h1>
+            <p class="page-hero-lead">AI Robot Japan is looking for members and partners who want to help build the community, not just take part. There are many ways to get involved — giving talks and live demos, hosting a venue, sponsoring, or organizing. Reach out anytime.</p>
+            <a href="#apply" class="btn btn-primary">Get in touch</a>
+        </div>
+    </header>
+
+    <!-- Roles -->
+    <section class="section recruit">
+        <div class="container">
+            <p class="section-eyebrow">OPPORTUNITIES</p>
+            <h2 class="section-title">Open roles</h2>
+            <div class="recruit-grid">
+                <article class="recruit-card">
+                    <span class="activity-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="22"/></svg>
+                    </span>
+                    <h3>Talks, LTs &amp; live demos</h3>
+                    <p class="recruit-for"><span>WHO IT'S FOR</span>Anyone who wants to share R&amp;D insights, or bring their own machine or product to show. Stories about implementation struggles and lightning talks are very welcome.</p>
+                    <p class="recruit-get"><span>WHAT YOU CAN DO</span>Present at study sessions and conferences, exhibit live demos, and share knowledge with the community.</p>
+                    <a href="mailto:hello@ai-robot-japan.org?subject=%5BTalk%2FDemo%20application%5D" class="btn btn-content">Get in touch</a>
+                </article>
+                <article class="recruit-card">
+                    <span class="activity-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18"/><path d="M5 21V7l7-4 7 4v14"/><path d="M9 21v-6h6v6"/></svg>
+                    </span>
+                    <h3>Host a venue</h3>
+                    <p class="recruit-for"><span>WHO IT'S FOR</span>Companies and organizations with space for study sessions or hackathons. Beyond Tokyo — we are planning events nationwide.</p>
+                    <p class="recruit-get"><span>WHAT YOU CAN DO</span>Co-hosting credit, hosting a tech community at your site, and connecting with participants.</p>
+                    <a href="mailto:hello@ai-robot-japan.org?subject=%5BVenue%20inquiry%5D" class="btn btn-content">Discuss a venue</a>
+                </article>
+                <article class="recruit-card">
+                    <span class="activity-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/></svg>
+                    </span>
+                    <h3>Co-hosting &amp; sponsorship</h3>
+                    <p class="recruit-for"><span>WHO IT'S FOR</span>Companies that want to support the community and are interested in visibility and recruiting touchpoints in physical AI.</p>
+                    <p class="recruit-get"><span>WHAT YOU CAN DO</span>Logo placement at events and on the site, speaking slots, reach to participants, and recruiting or joint-development touchpoints.</p>
+                    <a href="mailto:hello@ai-robot-japan.org?subject=%5BSponsorship%20inquiry%5D" class="btn btn-content">Discuss sponsorship</a>
+                </article>
+                <article class="recruit-card">
+                    <span class="activity-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                    </span>
+                    <h3>Organizing team</h3>
+                    <p class="recruit-for"><span>WHO IT'S FOR</span>People who want to help plan, run, and share our activities — and shape the community itself.</p>
+                    <p class="recruit-get"><span>WHAT YOU CAN DO</span>Event planning and operations, podcast and social outreach, and working as a core member of the community.</p>
+                    <a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer" class="btn btn-content">Join organizing on Discord</a>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <!-- Flow -->
+    <section class="section recruit-flow">
+        <div class="container">
+            <p class="section-eyebrow">FLOW</p>
+            <h2 class="section-title">How to apply</h2>
+            <ol class="flow-steps">
+                <li>
+                    <span class="flow-num">1</span>
+                    <h3>Get in touch</h3>
+                    <p>Let us know which role interests you, by email or on Discord. Your idea doesn't need to be fully formed.</p>
+                </li>
+                <li>
+                    <span class="flow-num">2</span>
+                    <h3>Align with organizers</h3>
+                    <p>We work out the theme, schedule, talk content, and terms together with the organizing team.</p>
+                </li>
+                <li>
+                    <span class="flow-num">3</span>
+                    <h3>Prepare</h3>
+                    <p>We prepare announcements, materials, and equipment together, and support you where needed.</p>
+                </li>
+                <li>
+                    <span class="flow-num">4</span>
+                    <h3>Host or take part</h3>
+                    <p>Run the event, or start your work as an organizer or partner.</p>
+                </li>
+            </ol>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="section recruit-faq">
+        <div class="container">
+            <p class="section-eyebrow">FAQ</p>
+            <h2 class="section-title">Frequently asked questions</h2>
+            <div class="faq-list">
+                <details>
+                    <summary>Can beginners give talks?</summary>
+                    <p>Yes. Beyond cutting-edge research, we welcome stories of implementation struggles, experiments you've tried, and short lightning talks. Sharing the process of building and running is exactly what we value.</p>
+                </details>
+                <details>
+                    <summary>Can individuals and companies both apply?</summary>
+                    <p>Both are welcome — from individual talks and participation to corporate venue hosting and sponsorship. Reach out about whatever fits your involvement.</p>
+                </details>
+                <details>
+                    <summary>Are there any costs?</summary>
+                    <p>Speaking, attending, and joining the organizing team are free. For co-hosting and sponsorship, let's discuss the details case by case.</p>
+                </details>
+                <details>
+                    <summary>Can you hold events outside Tokyo?</summary>
+                    <p>Yes. With a venue, we are planning events nationwide, including Osaka, Kyoto, and Nagoya. We welcome inquiries about hosting in your region.</p>
+                </details>
+                <details>
+                    <summary>Can I join online?</summary>
+                    <p>Because we emphasize hands-on demos, events are mainly in person, but we also consider online or hybrid formats for some. Just ask.</p>
+                </details>
+            </div>
+        </div>
+    </section>
+
+    <!-- Get in touch -->
+    <section id="apply" class="section recruit-cta">
+        <div class="container">
+            <p class="section-eyebrow">GET IN TOUCH</p>
+            <h2 class="section-title">Get in touch</h2>
+            <p class="recruit-cta-lead">Reach out anytime. We welcome inquiries even when your plans aren't fully decided yet.</p>
+            <!-- TODO: When a Google Form is ready, add <a href="FORM_URL" class="btn btn-primary">Open the application form</a> here and swap out the mail/Discord actions if needed -->
+            <div class="recruit-cta-actions">
+                <a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer" class="btn btn-primary">Ask on Discord</a>
+                <a href="mailto:hello@ai-robot-japan.org?subject=%5BRecruit%20inquiry%5D" class="btn btn-ghost">Email us</a>
+            </div>
+            <p class="contact-email">hello@ai-robot-japan.org</p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>AI Robot Japan</h3>
+                    <p>An AI robotics community</p>
+                </div>
+                <div class="footer-section">
+                    <h4>Links</h4>
+                    <ul>
+                        <li><a href="/en/index.html#latest">Latest</a></li>
+                        <li><a href="/en/index.html#about">About</a></li>
+                        <li><a href="/en/index.html#atmosphere">What we value</a></li>
+                        <li><a href="/en/index.html#activities">Activities</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>Content</h4>
+                    <ul>
+                        <li><a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer">Discord</a></li>
+                        <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">Events</a></li>
+                        <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                        <li><a href="/en/recruit.html">Recruit</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p>&copy; 2026 AI Robot Japan. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/recruit.html
+++ b/recruit.html
@@ -2,6 +2,21 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
+    <script>
+        (function () {
+            try {
+                var p = location.pathname, onEn = /^\/en(\/|$)/.test(p);
+                var s = localStorage.getItem('arj-lang');
+                var wantEn = s ? s === 'en' : (navigator.language || '').toLowerCase().indexOf('ja') !== 0;
+                if (wantEn && !onEn) {
+                    location.replace((p === '/' || p === '' ? '/en/index.html' : '/en' + p) + location.search + location.hash);
+                } else if (!wantEn && onEn) {
+                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/index.html';
+                    location.replace(t + location.search + location.hash);
+                }
+            } catch (e) {}
+        })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="AI Robot Japan の募集ページ。登壇・実機デモ、会場提供、共催・協賛、運営スタッフを募集しています。">
     <meta property="og:title" content="募集 | AI Robot Japan">
@@ -11,13 +26,16 @@
     <meta property="og:image" content="https://ai-robot-japan.org/assets/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="theme-color" content="#d5191f">
+    <link rel="alternate" hreflang="ja" href="https://ai-robot-japan.org/recruit.html">
+    <link rel="alternate" hreflang="en" href="https://ai-robot-japan.org/en/recruit.html">
+    <link rel="alternate" hreflang="x-default" href="https://ai-robot-japan.org/recruit.html">
     <title>募集 | AI Robot Japan</title>
     <link rel="icon" type="image/png" href="./assets/favicon.png">
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=8">
+    <link rel="stylesheet" href="./styles.css?v=9">
 </head>
 <body>
     <!-- ナビゲーション -->
@@ -33,6 +51,7 @@
                 <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
                 <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
                 <li><a href="/recruit.html" class="nav-cta">募集</a></li>
+                <li><a href="/en/recruit.html" class="nav-lang" onclick="localStorage.setItem('arj-lang','en')">EN</a></li>
             </ul>
         </div>
     </nav>

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,21 @@ body {
     color: #ffffff;
 }
 
+.nav-menu a.nav-lang {
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 0.3rem 0.7rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--text-light);
+    letter-spacing: 0.03em;
+}
+
+.nav-menu a.nav-lang:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
 /* ヒーローセクション */
 .hero {
     background:


### PR DESCRIPTION
## 概要
海外（非日本語ブラウザ）からのアクセス時に英語版を表示できるようにします。GitHub Pages は静的ホスティングのため IP による国判定はできず、`navigator.language` による言語判定方式を採用しています（所在地より「読める言語」で出し分け）。

## 変更
- **英語版ページ**：`/en/index.html`, `/en/recruit.html`（手書き翻訳、AIRoA調の簡潔なトーン）
- **自動切替**：`<head>` 先頭のスクリプトで `navigator.language` を判定し、非日本語ブラウザは `/en/` へ `location.replace`。ユーザーが手動で選んだ言語は `localStorage('arj-lang')` に保存して優先（ループなし）
- **手動トグル**：全ページのナビに `EN ⇄ 日本語` を追加
- **SEO**：`hreflang`（ja / en / x-default）を各ページに付与
- 英語ページは資産/データを絶対パス参照、LATESTのステータスを英語化（Upcoming/Past）、`styles.css?v=9`

## 確認済み
- 4ページとも 200、EN/JA レンダリング、データ読み込み（英語ステータス）
- ja-JPブラウザは日本語版維持・英語希望保存時は英語版維持（ループなし）、手動トグル往復、ナビ表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)