### PR TITLE
スマホ用ハンバーガーメニュー（PR #36マージ後の追加分）

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=9">
+    <link rel="stylesheet" href="/styles.css?v=11">
 </head>
 <body>
     <!-- Navigation -->
@@ -44,7 +44,10 @@
             <div class="nav-brand">
                 <a href="/en/index.html"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
-            <ul class="nav-menu">
+            <button class="nav-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="nav-menu">
+                <span></span><span></span><span></span>
+            </button>
+            <ul class="nav-menu" id="nav-menu">
                 <li><a href="#latest">Latest</a></li>
                 <li><a href="#about">About</a></li>
                 <li><a href="#activities">Activities</a></li>
@@ -444,6 +447,23 @@
                 renderError(podcastContainer, 'Could not load the podcast.');
             }
         });
+    </script>
+    <script>
+        (function () {
+            var toggle = document.querySelector('.nav-toggle');
+            var navbar = document.querySelector('.navbar');
+            if (!toggle || !navbar) return;
+            toggle.addEventListener('click', function () {
+                var open = navbar.classList.toggle('nav-open');
+                toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+            });
+            navbar.querySelectorAll('.nav-menu a').forEach(function (a) {
+                a.addEventListener('click', function () {
+                    navbar.classList.remove('nav-open');
+                    toggle.setAttribute('aria-expanded', 'false');
+                });
+            });
+        })();
     </script>
 </body>
 </html>

--- a/en/recruit.html
+++ b/en/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=9">
+    <link rel="stylesheet" href="/styles.css?v=11">
 </head>
 <body>
     <!-- Navigation -->
@@ -44,7 +44,10 @@
             <div class="nav-brand">
                 <a href="/en/index.html"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
-            <ul class="nav-menu">
+            <button class="nav-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="nav-menu">
+                <span></span><span></span><span></span>
+            </button>
+            <ul class="nav-menu" id="nav-menu">
                 <li><a href="/en/index.html#latest">Latest</a></li>
                 <li><a href="/en/index.html#about">About</a></li>
                 <li><a href="/en/index.html#activities">Activities</a></li>
@@ -219,5 +222,22 @@
             </div>
         </div>
     </footer>
+    <script>
+        (function () {
+            var toggle = document.querySelector('.nav-toggle');
+            var navbar = document.querySelector('.navbar');
+            if (!toggle || !navbar) return;
+            toggle.addEventListener('click', function () {
+                var open = navbar.classList.toggle('nav-open');
+                toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+            });
+            navbar.querySelectorAll('.nav-menu a').forEach(function (a) {
+                a.addEventListener('click', function () {
+                    navbar.classList.remove('nav-open');
+                    toggle.setAttribute('aria-expanded', 'false');
+                });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=9">
+    <link rel="stylesheet" href="./styles.css?v=11">
 </head>
 <body>
     <!-- ナビゲーション -->
@@ -44,7 +44,10 @@
             <div class="nav-brand">
                 <a href="/index.html"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
-            <ul class="nav-menu">
+            <button class="nav-toggle" type="button" aria-label="メニューを開閉" aria-expanded="false" aria-controls="nav-menu">
+                <span></span><span></span><span></span>
+            </button>
+            <ul class="nav-menu" id="nav-menu">
                 <li><a href="#latest">新着</a></li>
                 <li><a href="#about">概要</a></li>
                 <li><a href="#activities">活動</a></li>
@@ -444,6 +447,23 @@
                 renderError(podcastContainer, 'Podcast情報を取得できませんでした。');
             }
         });
+    </script>
+    <script>
+        (function () {
+            var toggle = document.querySelector('.nav-toggle');
+            var navbar = document.querySelector('.navbar');
+            if (!toggle || !navbar) return;
+            toggle.addEventListener('click', function () {
+                var open = navbar.classList.toggle('nav-open');
+                toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+            });
+            navbar.querySelectorAll('.nav-menu a').forEach(function (a) {
+                a.addEventListener('click', function () {
+                    navbar.classList.remove('nav-open');
+                    toggle.setAttribute('aria-expanded', 'false');
+                });
+            });
+        })();
     </script>
 </body>
 </html>

--- a/recruit.html
+++ b/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=9">
+    <link rel="stylesheet" href="./styles.css?v=11">
 </head>
 <body>
     <!-- ナビゲーション -->
@@ -44,7 +44,10 @@
             <div class="nav-brand">
                 <a href="/index.html"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
-            <ul class="nav-menu">
+            <button class="nav-toggle" type="button" aria-label="メニューを開閉" aria-expanded="false" aria-controls="nav-menu">
+                <span></span><span></span><span></span>
+            </button>
+            <ul class="nav-menu" id="nav-menu">
                 <li><a href="/index.html#latest">新着</a></li>
                 <li><a href="/index.html#about">概要</a></li>
                 <li><a href="/index.html#activities">活動</a></li>
@@ -219,5 +222,22 @@
             </div>
         </div>
     </footer>
+    <script>
+        (function () {
+            var toggle = document.querySelector('.nav-toggle');
+            var navbar = document.querySelector('.navbar');
+            if (!toggle || !navbar) return;
+            toggle.addEventListener('click', function () {
+                var open = navbar.classList.toggle('nav-open');
+                toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+            });
+            navbar.querySelectorAll('.nav-menu a').forEach(function (a) {
+                a.addEventListener('click', function () {
+                    navbar.classList.remove('nav-open');
+                    toggle.setAttribute('aria-expanded', 'false');
+                });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -118,6 +118,41 @@ body {
     border-color: var(--accent);
 }
 
+/* ハンバーガーボタン（モバイルのみ表示） */
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.nav-toggle span {
+    display: block;
+    width: 24px;
+    height: 2px;
+    border-radius: 2px;
+    background: var(--text-dark);
+    transition: transform 0.25s ease, opacity 0.2s ease;
+}
+
+.navbar.nav-open .nav-toggle span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+}
+
+.navbar.nav-open .nav-toggle span:nth-child(2) {
+    opacity: 0;
+}
+
+.navbar.nav-open .nav-toggle span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+}
+
 /* ヒーローセクション */
 .hero {
     background:
@@ -1005,10 +1040,44 @@ body {
 }
 
 @media (max-width: 768px) {
-    .nav-menu {
+    .navbar .container {
         flex-wrap: wrap;
-        gap: 1rem;
-        justify-content: center;
+    }
+
+    .nav-toggle {
+        display: flex;
+    }
+
+    .nav-menu {
+        display: none;
+        flex-basis: 100%;
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0;
+    }
+
+    .navbar.nav-open .nav-menu {
+        display: flex;
+        padding-top: 0.5rem;
+    }
+
+    .nav-menu li {
+        width: 100%;
+    }
+
+    .nav-menu a {
+        display: block;
+        padding: 0.85rem 0.25rem;
+        border-top: 1px solid var(--border-color);
+    }
+
+    .nav-menu a.nav-cta,
+    .nav-menu a.nav-lang {
+        display: inline-block;
+        width: auto;
+        margin: 0.6rem 0.25rem 0;
+        border-top: 0;
     }
 
     .nav-logo {
@@ -1080,11 +1149,6 @@ body {
 }
 
 @media (max-width: 480px) {
-    .navbar .container {
-        flex-direction: column;
-        gap: 0.75rem;
-    }
-
     .hero-actions .btn {
         width: 100%;
         text-align: center;


### PR DESCRIPTION
## 概要
PR #36 が「英語版」コミットの時点でマージされ、その後に追加した**スマホ用ハンバーガーメニュー**のコミットが main に取り込まれていなかったため、反映します。

## 変更
- 768px以下でナビをハンバーガー（☰ → ✕）に畳み、タップで縦並びドロップダウンを開閉。リンクタップで自動的に閉じる
- デスクトップは従来どおり（ハンバーガー非表示）
- 日本語・英語の全4ページに適用、`styles.css?v=11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)