### PR TITLE
クリーンURL化（index.html を出さない）

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -9,9 +9,9 @@
                 var s = localStorage.getItem('arj-lang');
                 var wantEn = s ? s === 'en' : (navigator.language || '').toLowerCase().indexOf('ja') !== 0;
                 if (wantEn && !onEn) {
-                    location.replace((p === '/' || p === '' ? '/en/index.html' : '/en' + p) + location.search + location.hash);
+                    location.replace((p === '/' || p === '' ? '/en/' : '/en' + p) + location.search + location.hash);
                 } else if (!wantEn && onEn) {
-                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/index.html';
+                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/';
                     location.replace(t + location.search + location.hash);
                 }
             } catch (e) {}
@@ -22,13 +22,13 @@
     <meta property="og:title" content="AI Robot Japan - AI Robot Community">
     <meta property="og:description" content="A community of AI-robotics practitioners in Japan, driving everything from R&D to real-world deployment. Study sessions, hackathons, conferences, and a podcast, year-round.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://ai-robot-japan.org/en/index.html">
+    <meta property="og:url" content="https://ai-robot-japan.org/en/">
     <meta property="og:image" content="https://ai-robot-japan.org/assets/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="theme-color" content="#d5191f">
-    <link rel="alternate" hreflang="ja" href="https://ai-robot-japan.org/index.html">
-    <link rel="alternate" hreflang="en" href="https://ai-robot-japan.org/en/index.html">
-    <link rel="alternate" hreflang="x-default" href="https://ai-robot-japan.org/index.html">
+    <link rel="alternate" hreflang="ja" href="https://ai-robot-japan.org/">
+    <link rel="alternate" hreflang="en" href="https://ai-robot-japan.org/en/">
+    <link rel="alternate" hreflang="x-default" href="https://ai-robot-japan.org/">
     <title>AI Robot Japan - AI Robot Community</title>
     <link rel="icon" type="image/png" href="/assets/favicon.png">
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png">
@@ -42,7 +42,7 @@
     <nav class="navbar">
         <div class="container">
             <div class="nav-brand">
-                <a href="/en/index.html"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
+                <a href="/en/"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
             <button class="nav-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="nav-menu">
                 <span></span><span></span><span></span>
@@ -55,7 +55,7 @@
                 <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
                 <li><a href="/en/recruit.html">Recruit</a></li>
                 <li><a href="#contact" class="nav-cta">Join</a></li>
-                <li><a href="/index.html" class="nav-lang" onclick="localStorage.setItem('arj-lang','ja')">日本語</a></li>
+                <li><a href="/" class="nav-lang" onclick="localStorage.setItem('arj-lang','ja')">日本語</a></li>
             </ul>
         </div>
     </nav>

--- a/en/recruit.html
+++ b/en/recruit.html
@@ -9,9 +9,9 @@
                 var s = localStorage.getItem('arj-lang');
                 var wantEn = s ? s === 'en' : (navigator.language || '').toLowerCase().indexOf('ja') !== 0;
                 if (wantEn && !onEn) {
-                    location.replace((p === '/' || p === '' ? '/en/index.html' : '/en' + p) + location.search + location.hash);
+                    location.replace((p === '/' || p === '' ? '/en/' : '/en' + p) + location.search + location.hash);
                 } else if (!wantEn && onEn) {
-                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/index.html';
+                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/';
                     location.replace(t + location.search + location.hash);
                 }
             } catch (e) {}
@@ -42,15 +42,15 @@
     <nav class="navbar">
         <div class="container">
             <div class="nav-brand">
-                <a href="/en/index.html"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
+                <a href="/en/"><img class="nav-logo" src="/assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
             <button class="nav-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="nav-menu">
                 <span></span><span></span><span></span>
             </button>
             <ul class="nav-menu" id="nav-menu">
-                <li><a href="/en/index.html#latest">Latest</a></li>
-                <li><a href="/en/index.html#about">About</a></li>
-                <li><a href="/en/index.html#activities">Activities</a></li>
+                <li><a href="/en/#latest">Latest</a></li>
+                <li><a href="/en/#about">About</a></li>
+                <li><a href="/en/#activities">Activities</a></li>
                 <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">Events</a></li>
                 <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
                 <li><a href="/en/recruit.html" class="nav-cta">Recruit</a></li>
@@ -201,10 +201,10 @@
                 <div class="footer-section">
                     <h4>Links</h4>
                     <ul>
-                        <li><a href="/en/index.html#latest">Latest</a></li>
-                        <li><a href="/en/index.html#about">About</a></li>
-                        <li><a href="/en/index.html#atmosphere">What we value</a></li>
-                        <li><a href="/en/index.html#activities">Activities</a></li>
+                        <li><a href="/en/#latest">Latest</a></li>
+                        <li><a href="/en/#about">About</a></li>
+                        <li><a href="/en/#atmosphere">What we value</a></li>
+                        <li><a href="/en/#activities">Activities</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">

--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
                 var s = localStorage.getItem('arj-lang');
                 var wantEn = s ? s === 'en' : (navigator.language || '').toLowerCase().indexOf('ja') !== 0;
                 if (wantEn && !onEn) {
-                    location.replace((p === '/' || p === '' ? '/en/index.html' : '/en' + p) + location.search + location.hash);
+                    location.replace((p === '/' || p === '' ? '/en/' : '/en' + p) + location.search + location.hash);
                 } else if (!wantEn && onEn) {
-                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/index.html';
+                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/';
                     location.replace(t + location.search + location.hash);
                 }
             } catch (e) {}
@@ -26,9 +26,9 @@
     <meta property="og:image" content="https://ai-robot-japan.org/assets/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="theme-color" content="#d5191f">
-    <link rel="alternate" hreflang="ja" href="https://ai-robot-japan.org/index.html">
-    <link rel="alternate" hreflang="en" href="https://ai-robot-japan.org/en/index.html">
-    <link rel="alternate" hreflang="x-default" href="https://ai-robot-japan.org/index.html">
+    <link rel="alternate" hreflang="ja" href="https://ai-robot-japan.org/">
+    <link rel="alternate" hreflang="en" href="https://ai-robot-japan.org/en/">
+    <link rel="alternate" hreflang="x-default" href="https://ai-robot-japan.org/">
     <title>AI Robot Japan - AI Robot Community</title>
     <link rel="icon" type="image/png" href="./assets/favicon.png">
     <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png">
@@ -42,7 +42,7 @@
     <nav class="navbar">
         <div class="container">
             <div class="nav-brand">
-                <a href="/index.html"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
+                <a href="/"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
             <button class="nav-toggle" type="button" aria-label="メニューを開閉" aria-expanded="false" aria-controls="nav-menu">
                 <span></span><span></span><span></span>
@@ -55,7 +55,7 @@
                 <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
                 <li><a href="/recruit.html">募集</a></li>
                 <li><a href="#contact" class="nav-cta">参加する</a></li>
-                <li><a href="/en/index.html" class="nav-lang" onclick="localStorage.setItem('arj-lang','en')">EN</a></li>
+                <li><a href="/en/" class="nav-lang" onclick="localStorage.setItem('arj-lang','en')">EN</a></li>
             </ul>
         </div>
     </nav>

--- a/recruit.html
+++ b/recruit.html
@@ -9,9 +9,9 @@
                 var s = localStorage.getItem('arj-lang');
                 var wantEn = s ? s === 'en' : (navigator.language || '').toLowerCase().indexOf('ja') !== 0;
                 if (wantEn && !onEn) {
-                    location.replace((p === '/' || p === '' ? '/en/index.html' : '/en' + p) + location.search + location.hash);
+                    location.replace((p === '/' || p === '' ? '/en/' : '/en' + p) + location.search + location.hash);
                 } else if (!wantEn && onEn) {
-                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/index.html';
+                    var t = p.replace(/^\/en/, ''); if (t === '' || t === '/') t = '/';
                     location.replace(t + location.search + location.hash);
                 }
             } catch (e) {}
@@ -42,15 +42,15 @@
     <nav class="navbar">
         <div class="container">
             <div class="nav-brand">
-                <a href="/index.html"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
+                <a href="/"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
             </div>
             <button class="nav-toggle" type="button" aria-label="メニューを開閉" aria-expanded="false" aria-controls="nav-menu">
                 <span></span><span></span><span></span>
             </button>
             <ul class="nav-menu" id="nav-menu">
-                <li><a href="/index.html#latest">新着</a></li>
-                <li><a href="/index.html#about">概要</a></li>
-                <li><a href="/index.html#activities">活動</a></li>
+                <li><a href="/#latest">新着</a></li>
+                <li><a href="/#about">概要</a></li>
+                <li><a href="/#activities">活動</a></li>
                 <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
                 <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
                 <li><a href="/recruit.html" class="nav-cta">募集</a></li>
@@ -201,10 +201,10 @@
                 <div class="footer-section">
                     <h4>リンク</h4>
                     <ul>
-                        <li><a href="/index.html#latest">新着</a></li>
-                        <li><a href="/index.html#about">概要</a></li>
-                        <li><a href="/index.html#atmosphere">大切にしていること</a></li>
-                        <li><a href="/index.html#activities">活動</a></li>
+                        <li><a href="/#latest">新着</a></li>
+                        <li><a href="/#about">概要</a></li>
+                        <li><a href="/#atmosphere">大切にしていること</a></li>
+                        <li><a href="/#activities">活動</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">


### PR DESCRIPTION
## 概要
今どきのサイトに合わせ、URLから `index.html` を出さないようにします（ホームは `ai-robot-japan.org/`）。

## 変更
- ナビ・フッター・言語トグル・`hreflang`・`og:url`・言語判定スクリプトの `/index.html` を `/` に、`/en/index.html` を `/en/` に統一
- GitHub Pages は `/` と `/en/` をそれぞれ index として配信するため挙動は不変
- `recruit.html` はそのまま（index.html ではないため）

## 確認済み（プレビュー）
- `/` 表示・index.htmlリンクゼロ・nav-brand→`/`
- 言語自動判定：英語希望で `/`→`/en/`、日本語希望で `/en/`→`/`（ループなし）
- 手動トグル EN⇄日本語

🤖 Generated with [Claude Code](https://claude.com/claude-code)