### PR TITLE
ナビゲーションのロゴを拡大（視認性向上）

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=11">
+    <link rel="stylesheet" href="/styles.css?v=12">
 </head>
 <body>
     <!-- Navigation -->

--- a/en/recruit.html
+++ b/en/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=11">
+    <link rel="stylesheet" href="/styles.css?v=12">
 </head>
 <body>
     <!-- Navigation -->

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=11">
+    <link rel="stylesheet" href="./styles.css?v=12">
 </head>
 <body>
     <!-- ナビゲーション -->

--- a/recruit.html
+++ b/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=11">
+    <link rel="stylesheet" href="./styles.css?v=12">
 </head>
 <body>
     <!-- ナビゲーション -->

--- a/styles.css
+++ b/styles.css
@@ -65,7 +65,7 @@ body {
 }
 
 .nav-logo {
-    height: 46px;
+    height: 58px;
     width: auto;
     display: block;
 }
@@ -1081,7 +1081,7 @@ body {
     }
 
     .nav-logo {
-        height: 38px;
+        height: 48px;
     }
 
     .hero {


### PR DESCRIPTION
## 概要
ナビゲーションのロゴマークが小さく視認性が低かったため拡大します。

## 変更
- `.nav-logo` の高さを 46px → **58px**（デスクトップ）、38px → **48px**（モバイル）に
- `styles.css?v=12`

## 確認済み（プレビュー）
- デスクトップ/モバイルともロボットマークがはっきり視認でき、ナビ項目・ハンバーガーとのバランスも良好

🤖 Generated with [Claude Code](https://claude.com/claude-code)