### PR TITLE
公式Xアカウントへのリンク追加

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=12">
+    <link rel="stylesheet" href="/styles.css?v=13">
 </head>
 <body>
     <!-- Navigation -->
@@ -275,6 +275,11 @@
                     <a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer" class="btn btn-content">Listen on Spotify</a>
                 </div>
                 <div class="join-card">
+                    <h3>X (Twitter)</h3>
+                    <p>We post event announcements and community updates on our official X account.</p>
+                    <a href="https://x.com/AIRobotJapan" target="_blank" rel="noopener noreferrer" class="btn btn-content">Follow @AIRobotJapan</a>
+                </div>
+                <div class="join-card">
                     <h3>Contact</h3>
                     <p>For partnerships, talks, sponsorships, and other inquiries, please email us.</p>
                     <p class="contact-email">hello@ai-robot-japan.org</p>
@@ -316,6 +321,7 @@
                         <li><a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer">Discord</a></li>
                         <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">Events</a></li>
                         <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                        <li><a href="https://x.com/AIRobotJapan" target="_blank" rel="noopener noreferrer">X (Twitter)</a></li>
                         <li><a href="/en/recruit.html">Recruit</a></li>
                     </ul>
                 </div>

--- a/en/recruit.html
+++ b/en/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=12">
+    <link rel="stylesheet" href="/styles.css?v=13">
 </head>
 <body>
     <!-- Navigation -->
@@ -213,6 +213,7 @@
                         <li><a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer">Discord</a></li>
                         <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">Events</a></li>
                         <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                        <li><a href="https://x.com/AIRobotJapan" target="_blank" rel="noopener noreferrer">X (Twitter)</a></li>
                         <li><a href="/en/recruit.html">Recruit</a></li>
                     </ul>
                 </div>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=12">
+    <link rel="stylesheet" href="./styles.css?v=13">
 </head>
 <body>
     <!-- ナビゲーション -->
@@ -275,6 +275,11 @@
                     <a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer" class="btn btn-content">Spotifyで聴く</a>
                 </div>
                 <div class="join-card">
+                    <h3>X（旧Twitter）</h3>
+                    <p>イベントの告知や活動の最新情報を、公式Xアカウントで発信しています。</p>
+                    <a href="https://x.com/AIRobotJapan" target="_blank" rel="noopener noreferrer" class="btn btn-content">@AIRobotJapanをフォロー</a>
+                </div>
+                <div class="join-card">
                     <h3>お問い合わせ</h3>
                     <p>協業・登壇・スポンサー等のご相談は、メールにてご連絡ください。</p>
                     <p class="contact-email">hello@ai-robot-japan.org</p>
@@ -316,6 +321,7 @@
                         <li><a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer">Discord</a></li>
                         <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
                         <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                        <li><a href="https://x.com/AIRobotJapan" target="_blank" rel="noopener noreferrer">X（旧Twitter）</a></li>
                         <li><a href="#contact">参加する・お問い合わせ</a></li>
                     </ul>
                 </div>

--- a/recruit.html
+++ b/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=12">
+    <link rel="stylesheet" href="./styles.css?v=13">
 </head>
 <body>
     <!-- ナビゲーション -->
@@ -213,6 +213,7 @@
                         <li><a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer">Discord</a></li>
                         <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
                         <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                        <li><a href="https://x.com/AIRobotJapan" target="_blank" rel="noopener noreferrer">X（旧Twitter）</a></li>
                         <li><a href="/recruit.html">募集</a></li>
                     </ul>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -687,7 +687,7 @@ body {
 /* 参加・問い合わせセクション */
 .join-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 1.5rem;
 }
 


### PR DESCRIPTION
## 概要
公式Xアカウント（https://x.com/AIRobotJapan ）へのリンクをサイトに追加します。

## 配置（日英両方）
- **「参加する / Get involved」セクション**：Discord・イベント・Podcastと並ぶ5枚目のカードとして追加（フォローCTA付き）。5枚になるためグリッドを3+2配置に調整
- **フッターの「コンテンツ / Content」欄**：全4ページに追加

ナビは項目過多になるため追加していません。

## 確認済み（プレビュー）
- JA/EN とも5カードが3+2で整列、ボタン折り返しなし
- フッターリンク・URL（x.com/AIRobotJapan、200確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)