### PR TITLE
プライバシーポリシーページ追加

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=13">
+    <link rel="stylesheet" href="/styles.css?v=14">
 </head>
 <body>
     <!-- Navigation -->
@@ -327,6 +327,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
+                <p><a href="/privacy.html">Privacy Policy</a></p>
                 <p>&copy; 2026 AI Robot Japan. All rights reserved.</p>
             </div>
         </div>

--- a/en/recruit.html
+++ b/en/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/styles.css?v=13">
+    <link rel="stylesheet" href="/styles.css?v=14">
 </head>
 <body>
     <!-- Navigation -->
@@ -219,6 +219,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
+                <p><a href="/privacy.html">Privacy Policy</a></p>
                 <p>&copy; 2026 AI Robot Japan. All rights reserved.</p>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=13">
+    <link rel="stylesheet" href="./styles.css?v=14">
 </head>
 <body>
     <!-- ナビゲーション -->
@@ -327,6 +327,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
+                <p><a href="/privacy.html">プライバシーポリシー</a></p>
                 <p>&copy; 2026 AI Robot Japan. All rights reserved.</p>
             </div>
         </div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="AI Robot Japan のプライバシーポリシー。参加者の個人情報の取扱いについて定めています。">
+    <meta property="og:title" content="プライバシーポリシー | AI Robot Japan">
+    <meta property="og:description" content="AI Robot Japan のプライバシーポリシー。参加者の個人情報の取扱いについて定めています。">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://ai-robot-japan.org/privacy.html">
+    <meta property="og:image" content="https://ai-robot-japan.org/assets/og-image.png">
+    <meta name="theme-color" content="#d5191f">
+    <title>プライバシーポリシー | AI Robot Japan</title>
+    <link rel="icon" type="image/png" href="./assets/favicon.png">
+    <link rel="apple-touch-icon" href="./assets/apple-touch-icon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./styles.css?v=14">
+</head>
+<body>
+    <!-- ナビゲーション -->
+    <nav class="navbar">
+        <div class="container">
+            <div class="nav-brand">
+                <a href="/"><img class="nav-logo" src="./assets/logo-horizontal.png" alt="AI Robot Japan"></a>
+            </div>
+            <button class="nav-toggle" type="button" aria-label="メニューを開閉" aria-expanded="false" aria-controls="nav-menu">
+                <span></span><span></span><span></span>
+            </button>
+            <ul class="nav-menu" id="nav-menu">
+                <li><a href="/#latest">新着</a></li>
+                <li><a href="/#about">概要</a></li>
+                <li><a href="/#activities">活動</a></li>
+                <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
+                <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                <li><a href="/recruit.html">募集</a></li>
+                <li><a href="/#contact" class="nav-cta">参加する</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <!-- ページヘッダー -->
+    <header class="page-hero">
+        <div class="container">
+            <p class="hero-eyebrow">PRIVACY POLICY</p>
+            <h1 class="page-hero-title">プライバシーポリシー</h1>
+        </div>
+    </header>
+
+    <!-- 本文 -->
+    <main class="section legal">
+        <div class="container">
+            <div class="legal-content">
+                <p>
+                    AI Robot Japan（以下「当コミュニティ」といいます。）は、当コミュニティの活動に参加する方（以下「参加者」といいます。）の個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定め、個人情報保護の仕組みを構築し、運営メンバー全員に個人情報保護の重要性を認識させるとともにその取組みを徹底させることにより、個人情報の保護を推進します。
+                </p>
+                <p>
+                    本ポリシーにおいて「本活動」とは、当コミュニティが主催又は共催するオフライン・オンラインの勉強会、工場見学、企業訪問、カンファレンスその他のイベント、並びにウェブサイト・SNS・メディア等を通じた情報発信を含む、当コミュニティの一切の活動をいいます。
+                </p>
+
+                <h2>第1条（個人情報）</h2>
+                <p>
+                    「個人情報」とは、個人情報の保護に関する法律（平成十五年法律第五十七号、以下「個人情報保護法」といいます。）にいう「個人情報」を指し、生存する個人に関する情報であって、当該情報に含まれる氏名、生年月日その他の記述等により特定の個人を識別できるもの又は個人識別符号が含まれるものを指します。
+                </p>
+
+                <h2>第2条（個人情報の利用目的）</h2>
+                <p>
+                    当コミュニティは、以下の目的に必要な範囲で、参加者の個人情報（氏名、所属、役職、連絡先、参加申込情報等を含みます。）を取得し、取得した情報を利用させていただきます。以下の目的の範囲を超えて個人情報を利用する場合には、事前に適切な方法で参加者からの同意を得るものとします。
+                </p>
+                <ol class="paren-list">
+                    <li>本活動（勉強会、工場見学、企業訪問、カンファレンス等のイベントを含みます。）の参加受付、本人確認、当日の運営及び参加者管理のため</li>
+                    <li>本活動の内容を改良・改善し、又は新たな企画を検討・開発するため</li>
+                    <li>イベントの開催案内、活動報告、ニュースレターその他当コミュニティからのお知らせ（電子メール、メッセージングサービスその他の方法によるものを含みます。）のため</li>
+                    <li>開催内容の変更、中止、重要なお知らせ等必要に応じたご連絡のため</li>
+                    <li>本活動に関する参加者からのご意見、お問い合わせ等に回答するため（本人確認を行うことを含みます。）</li>
+                    <li>本活動に関するアンケート・取材等のご協力依頼や各種イベントへのご参加をお願いし、又はその結果等をご報告するため</li>
+                    <li>イベントの参加状況等を調査・分析し、その結果を本活動の改良・企画に利用するため</li>
+                    <li>工場見学・企業訪問等のイベントにおいて、受入企業等における入館手続、安全管理及び秘密保持管理のために必要な参加者情報（氏名、所属等）を当該受入企業等へ提供するため</li>
+                    <li>参加者の承諾・申込みに基づく、当コミュニティ主催イベントの協賛企業、登壇企業等への個人情報の提供のため</li>
+                    <li>参加規約・行動規範等に違反した参加者や、不正・不当な目的で本活動を利用しようとする参加者の特定をし、ご参加をお断りするため</li>
+                </ol>
+
+                <h2>第3条（クッキー等の利用）</h2>
+                <ol class="num-list">
+                    <li>当コミュニティは、当コミュニティが運営するウェブサイト（以下「当サイト」といいます。）のアクセス解析等のためにクッキー（Cookie）その他情報収集モジュール等（以下「クッキー等」といいます。）の技術を使用して、当サイトへの参加者のアクセス情報、閲覧情報等を取得することができます。なお、クッキー等を通じて取得するこれらの情報（以下「クッキー情報」といいます。）には、単独で参加者自身を識別し特定できる情報は含まれておりません。</li>
+                    <li>参加者は当サイト上でのクッキー等の使用について設定することができます。クッキー等の使用を許可しない場合には、参加者のブラウザの設定等においてクッキー等を無効にすることができます。ただし、クッキー等を無効にした場合、当サイトの利便性が損なわれたり、当サイトで提供するサービスのご利用範囲が限定されたりすることがあります。</li>
+                    <li>当コミュニティは、クッキー情報を、当サイトの運営、品質維持、改善の目的のために活用させていただきます。</li>
+                </ol>
+
+                <h2>第4条（写真・動画等の取扱い）</h2>
+                <ol class="num-list">
+                    <li>当コミュニティは、イベントの記録及び広報のため、イベント会場等において写真・動画等を撮影し、参加者の肖像が含まれる写真・動画等を、当サイト、note等の外部メディア・ブログサービス、SNS、活動報告資料等に掲載することがあります。撮影・掲載が予定されるイベントについては、申込ページ又は会場においてその旨を明示します。</li>
+                    <li>参加者は、自己の肖像が含まれる写真・動画等の撮影又は掲載を希望しない場合、イベント当日に運営スタッフへ申し出ること、又は掲載後に第16条のお問合せ窓口へ連絡することにより、撮影の回避又は掲載の停止・削除を求めることができます。当コミュニティは、当該申出を受けた場合、合理的な範囲で速やかに対応します。</li>
+                </ol>
+
+                <h2>第5条（個人情報の管理と保護）</h2>
+                <ol class="num-list">
+                    <li>
+                        個人情報の管理は、厳重に行うこととし、次に掲げるときを除き、参加者の同意がない限り、第三者に対し個人情報を開示・提供することはいたしません。また、安全性を考慮し、個人情報への不正アクセス、個人情報の紛失、破壊、改ざん及び漏えい等のリスクに対する予防並びに是正に関する対策を講じます。
+                        <ol class="paren-list">
+                            <li>人の生命、身体又は財産の保護のために必要がある場合であって、参加者の同意を得ることが困難であるとき。</li>
+                            <li>公衆衛生の向上又は児童の健全な育成の推進のために特に必要がある場合であって、参加者の同意を得ることが困難であるとき。</li>
+                            <li>国の機関若しくは地方公共団体又はその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって、参加者の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがあるとき。</li>
+                            <li>その他法令で認められるとき。</li>
+                        </ol>
+                    </li>
+                    <li>第2条第8号又は第9号に基づき受入企業、協賛企業等へ参加者情報を提供する場合には、イベントの申込ページ等において提供先及び提供する情報の項目をあらかじめ明示し、参加者が当該イベントに申し込んだことをもって、当該提供に同意いただいたものとして取り扱います。</li>
+                </ol>
+
+                <h2>第6条（個人情報の取扱いの委託）</h2>
+                <p>
+                    当コミュニティは、利用目的の達成に必要な範囲内において、個人情報の取扱いの全部又は一部を第三者（イベント申込管理サービス、フォーム作成サービス、メール配信サービス、クラウドストレージサービス等の外部サービス提供事業者を含みます。）に委託する場合がございます。この場合、当コミュニティは、委託先としての適格性を十分審査するとともに、委託先に対する必要かつ適切な監督を行います。
+                </p>
+
+                <h2>第7条（個人情報の開示）</h2>
+                <p>
+                    参加者は、当コミュニティに対し、第10条に定める手続に従って、当コミュニティの保有する個人情報の開示を請求することができます。当コミュニティは、参加者から当該請求を受けたときは、参加者に対し、遅滞なくこれを開示します。開示方法は当コミュニティが合理的と判断する方法によるものとします。ただし、開示することにより次のいずれかに該当する場合は、その全部又は一部を開示しないこともあり、開示しない決定をした場合には、その旨を遅滞なく通知します。
+                </p>
+                <ol class="paren-list">
+                    <li>参加者又は第三者の生命、身体、財産その他の権利利益を害するおそれがある場合</li>
+                    <li>当コミュニティの運営の適正な実施に著しい支障を及ぼすおそれがある場合</li>
+                    <li>その他法令に違反することとなる場合</li>
+                </ol>
+
+                <h2>第8条（個人情報の訂正等）</h2>
+                <ol class="num-list">
+                    <li>参加者は、当コミュニティの保有する個人情報が誤った情報である場合には、当コミュニティに対し、第10条に定める手続に従って、当該個人情報の訂正、追加又は削除（以下「訂正等」といいます。）を請求することができます。</li>
+                    <li>前項の請求を受けた場合、当コミュニティは遅滞なく必要な調査を行い、その結果前項の請求に理由があると判断した場合には、遅滞なく当該個人情報の訂正等を行います。</li>
+                    <li>当コミュニティは、前項に基づき訂正等の実施・不実施について判断した場合には、遅滞なく、参加者ご本人に対してご連絡いたします。</li>
+                </ol>
+
+                <h2>第9条（個人情報の利用停止等）</h2>
+                <ol class="num-list">
+                    <li>参加者は、当コミュニティに対し、第10条に定める手続に従って、当コミュニティの保有する個人情報の利用の停止、消去又は第三者提供の停止（以下「利用停止等」といいます。）を請求することができます。</li>
+                    <li>当コミュニティは、前項の請求を受けた場合には、遅滞なく必要な調査を行い、その結果前項の請求に理由があると判断した場合には、当該個人情報の利用停止等を行います。ただし、個人情報の利用停止等に多額の費用を要する場合その他利用停止等を行うことが困難な場合であって、参加者の権利利益を保護するために必要なこれに代わるべき措置をとれるときは、この代替策を講じます。</li>
+                    <li>当コミュニティは、前項に基づき利用停止等の実施・不実施について判断した場合には、遅滞なく、参加者ご本人に対してご連絡いたします。</li>
+                </ol>
+
+                <h2>第10条（個人情報の開示等の手続）</h2>
+                <ol class="num-list">
+                    <li>参加者は、第7条から第9条に定める請求を行う場合には、第16条に定めるお問合せ窓口宛てに、氏名、連絡先及び請求の内容を明記の上、ご連絡ください。</li>
+                    <li>当コミュニティは、前項の請求を受けた場合、請求者がご本人（又はその正当な代理人）であることを確認するため、当コミュニティ所定の方法により本人確認をさせていただくことがあります。</li>
+                </ol>
+
+                <h2>第11条（プライバシーポリシーの変更手続）</h2>
+                <p>
+                    当コミュニティは本ポリシーの内容を適宜見直し、その改善に努めます。本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、変更することができるものとします。変更後のプライバシーポリシーは、当コミュニティ所定の方法により、参加者に通知し、又は当サイトに掲載したときから効力を生じるものとします。
+                </p>
+
+                <h2>第12条（法令、規範の遵守）</h2>
+                <p>
+                    当コミュニティは、保有する個人情報に関して適用される日本の法令、その他規範を遵守します。
+                </p>
+
+                <h2>第13条（苦情及び相談への対応）</h2>
+                <p>
+                    当コミュニティは、個人情報の取扱いに関する参加者からの苦情、相談を受け付け、適切かつ迅速に対応いたします。また、参加者からの当該個人情報の開示、訂正、追加、削除、利用又は提供の拒否等のご要望に対しても、迅速かつ適切に対応いたします。
+                </p>
+
+                <h2>第14条（安全管理措置）</h2>
+                <p>
+                    当コミュニティが参加者よりお預かりした個人情報は、個人情報へのアクセス権限を必要な運営メンバーに限定すること、及び外部からの不正アクセス防止のためのセキュリティ対策の実施等、組織的、物理的、人的、技術的施策を講じることで個人情報への不正な侵入、個人情報の紛失、破壊、改ざん及び漏えい等を防止いたします。
+                </p>
+                <p>
+                    万一、参加者の個人情報の漏えい等の事故が発生した場合、当コミュニティは、個人情報保護法及び関連するガイドラインに則り、速やかに個人情報保護委員会等への報告を行うとともに、類似事案の発生防止措置及び再発防止措置等の必要な対応を行います。
+                </p>
+
+                <h2>第15条（運営者情報）</h2>
+                <p>当コミュニティの名称、運営代表者及び個人情報保護責任者は以下のとおりです。</p>
+                <p>
+                    名称：AI Robot Japan<br>
+                    運営代表者：南里勇気<br>
+                    個人情報保護責任者：南里勇気
+                </p>
+
+                <h2>第16条（お問合せ窓口）</h2>
+                <p>当コミュニティの個人情報の取扱いに関するお問い合わせは以下までご連絡ください。</p>
+                <p>
+                    AI Robot Japan 運営事務局<br>
+                    Mail: hello@ai-robot-japan.org
+                </p>
+
+                <p class="legal-date">2026年07月24日制定・施行</p>
+            </div>
+        </div>
+    </main>
+
+    <!-- フッター -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <h3>AI Robot Japan</h3>
+                    <p>AIロボットコミュニティ</p>
+                </div>
+                <div class="footer-section">
+                    <h4>リンク</h4>
+                    <ul>
+                        <li><a href="/#latest">新着</a></li>
+                        <li><a href="/#about">概要</a></li>
+                        <li><a href="/#atmosphere">大切にしていること</a></li>
+                        <li><a href="/#activities">活動</a></li>
+                    </ul>
+                </div>
+                <div class="footer-section">
+                    <h4>コンテンツ</h4>
+                    <ul>
+                        <li><a href="https://discord.gg/pjjQ46tyy" target="_blank" rel="noopener noreferrer">Discord</a></li>
+                        <li><a href="https://ai-robot-japan.connpass.com/" target="_blank" rel="noopener noreferrer">イベント</a></li>
+                        <li><a href="https://open.spotify.com/show/3eTibJbIqve5Rne4MkS1Ao" target="_blank" rel="noopener noreferrer">Podcast</a></li>
+                        <li><a href="https://x.com/AIRobotJapan" target="_blank" rel="noopener noreferrer">X（旧Twitter）</a></li>
+                        <li><a href="/recruit.html">募集</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-bottom">
+                <p><a href="/privacy.html">プライバシーポリシー</a></p>
+                <p>&copy; 2026 AI Robot Japan. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        (function () {
+            var toggle = document.querySelector('.nav-toggle');
+            var navbar = document.querySelector('.navbar');
+            if (!toggle || !navbar) return;
+            toggle.addEventListener('click', function () {
+                var open = navbar.classList.toggle('nav-open');
+                toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+            });
+            navbar.querySelectorAll('.nav-menu a').forEach(function (a) {
+                a.addEventListener('click', function () {
+                    navbar.classList.remove('nav-open');
+                    toggle.setAttribute('aria-expanded', 'false');
+                });
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/recruit.html
+++ b/recruit.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="./styles.css?v=13">
+    <link rel="stylesheet" href="./styles.css?v=14">
 </head>
 <body>
     <!-- ナビゲーション -->
@@ -219,6 +219,7 @@
                 </div>
             </div>
             <div class="footer-bottom">
+                <p><a href="/privacy.html">プライバシーポリシー</a></p>
                 <p>&copy; 2026 AI Robot Japan. All rights reserved.</p>
             </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -964,6 +964,89 @@ body {
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
 }
 
+/* プライバシーポリシー等の法務ページ */
+.legal-content {
+    max-width: 800px;
+}
+
+.legal-content p {
+    color: var(--text-light);
+    font-size: 0.98rem;
+    line-height: 2.1;
+    margin-bottom: 1.75rem;
+}
+
+.legal-content h2 {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--text-dark);
+    margin: 3rem 0 1.25rem;
+    padding-left: 0.9rem;
+    border-left: 4px solid var(--accent);
+}
+
+.legal-content ol {
+    list-style: none;
+    margin: 0 0 1.75rem;
+}
+
+.legal-content ol li {
+    color: var(--text-light);
+    font-size: 0.98rem;
+    line-height: 2.1;
+    margin-bottom: 1rem;
+    position: relative;
+    padding-left: 2.4em;
+}
+
+.legal-content .num-list {
+    counter-reset: num;
+}
+
+.legal-content .num-list > li::before {
+    counter-increment: num;
+    content: counter(num) ".";
+    position: absolute;
+    left: 0.5em;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.legal-content .paren-list {
+    counter-reset: paren;
+}
+
+.legal-content .paren-list > li::before {
+    counter-increment: paren;
+    content: "(" counter(paren) ")";
+    position: absolute;
+    left: 0;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.legal-content li .paren-list {
+    margin-top: 1rem;
+    margin-bottom: 0;
+}
+
+.legal-date {
+    margin-top: 3rem;
+    text-align: right;
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.footer-bottom a {
+    color: #94a1a8;
+    text-decoration: none;
+}
+
+.footer-bottom a:hover {
+    color: #ffffff;
+    text-decoration: underline;
+}
+
 /* フッター */
 .footer {
     background-color: var(--ink-950);


### PR DESCRIPTION
## 概要
確定版のプライバシーポリシー（.pagesファイル）をベースに、`privacy.html` を新設します。

## 変更
- **privacy.html**：前文＋第1条〜第16条＋制定日（2026年07月24日）を全文掲載。本文は原文のまま、以下の整形で読みやすくしています：
  - 段落ごとに十分な行間・段落間隔（原文の改行崩れを解消）
  - 条ごとに赤アクセントの見出し
  - 「(1)〜(10)」「1.〜3.」形式の号・項をリストとして整形（第5条の入れ子構造も再現）
- **フッター**：全ページの最下部（©表記の上）に「プライバシーポリシー / Privacy Policy」リンクを追加
- 注：本ページは日本語のみのため、言語自動リダイレクトのスクリプトは意図的に載せていません（存在しない /en/privacy.html への転送を防ぐため）。英訳版が必要になれば別途作成できます

## 確認済み（プレビュー）
- 全16条・リスト番号・制定日の表示、行間・見出しのスタイル適用
- フッターリンク（5ページとも）

🤖 Generated with [Claude Code](https://claude.com/claude-code)