### PR TITLE
connpassメンバー数も自動更新にする

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,5 +1,6 @@
 {
-  "generated_at": "2026-08-05T00:58:59+00:00",
+  "generated_at": "2026-08-05T01:21:14+00:00",
+  "members": 674,
   "total": 5,
   "events": [
     {

--- a/data/podcast.json
+++ b/data/podcast.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-05T00:58:59+00:00",
+  "generated_at": "2026-08-05T01:21:14+00:00",
   "source": "rss",
   "total": 15,
   "episodes": [

--- a/en/index.html
+++ b/en/index.html
@@ -79,7 +79,7 @@
             </div>
             <div class="hero-stats">
                 <div class="stat">
-                    <span class="stat-number">650<small>+</small></span>
+                    <span class="stat-number" id="stat-members">650<small>+</small></span>
                     <span class="stat-label">connpass members</span>
                 </div>
                 <div class="stat">
@@ -415,6 +415,11 @@
             events.forEach((event) => {
                 container.appendChild(createContentItem(event, { showStatus: true }));
             });
+
+            const statMembers = document.getElementById('stat-members');
+            if (statMembers && Number.isFinite(data.members)) {
+                statMembers.textContent = data.members;
+            }
         }
 
         async function renderPodcast(container) {

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
             </div>
             <div class="hero-stats">
                 <div class="stat">
-                    <span class="stat-number">650<small>+</small></span>
+                    <span class="stat-number" id="stat-members">650<small>+</small></span>
                     <span class="stat-label">connpassメンバー</span>
                 </div>
                 <div class="stat">
@@ -415,6 +415,11 @@
             events.forEach((event) => {
                 container.appendChild(createContentItem(event, { showStatus: true }));
             });
+
+            const statMembers = document.getElementById('stat-members');
+            if (statMembers && Number.isFinite(data.members)) {
+                statMembers.textContent = data.members;
+            }
         }
 
         async function renderPodcast(container) {

--- a/scripts/update_content.py
+++ b/scripts/update_content.py
@@ -46,8 +46,21 @@ def now_iso():
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
+def parse_member_count(html):
+    """connpassグループページのサイドバーからメンバー数を取り出す。"""
+    m = re.search(
+        r'participation/"[^>]*>\D{0,3}<span[^>]*>([0-9,]+)</span>', html)
+    if not m:
+        return None
+    try:
+        return int(m.group(1).replace(",", ""))
+    except ValueError:
+        return None
+
+
 def fetch_events():
     html = http_get(CONNPASS_GROUP_URL)
+    members = parse_member_count(html)
     event_urls = sorted(set(re.findall(
         r"https://ai-robot-japan\.connpass\.com/event/\d+/", html)))
 
@@ -78,7 +91,12 @@ def fetch_events():
         })
 
     events.sort(key=lambda e: e["started_at"] or "", reverse=True)
-    return {"generated_at": now_iso(), "total": len(events), "events": events}
+    return {
+        "generated_at": now_iso(),
+        "members": members,
+        "total": len(events),
+        "events": events,
+    }
 
 
 def fetch_podcast_from_api():


### PR DESCRIPTION
## 問題
ヒーローの「connpassメンバー」が **650+ の直書き**のままでした。Podcastと同じく、実態（現在 **674人**）とずれていました。

## 対応
日次ワークフローでconnpassのグループページからメンバー数を取得し、表示に反映するようにしました。

- `scripts/update_content.py`：グループページのサイドバーからメンバー数を抽出し、`data/events.json` に `members` として保存
- 日本語版・英語版のヒーロー統計を、このデータから描画（取得できなかった場合は従来の静的な数字のまま）
- 実数を出すため「+」は外しました（Podcast本数の表示と同じ扱い）

## 確認済み（ローカル）
- 日英とも **650+ → 674** に更新されることを確認
- イベント・Podcastの表示も従来どおり

これで「メンバー数・イベント・Podcast」の3つとも自動更新になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)